### PR TITLE
🥉  [gha] update super-linter to 8.0.0

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,6 +9,7 @@ end_of_line = lf
 insert_final_newline = true
 indent_style = tab
 indent_size = 8
+switch_case_indent = true
 
 [*.md]
 indent_style = space

--- a/.editorconfig
+++ b/.editorconfig
@@ -9,6 +9,7 @@ end_of_line = lf
 insert_final_newline = true
 indent_style = tab
 indent_size = 8
+# shfmt
 switch_case_indent = true
 
 [*.md]

--- a/.editorconfig
+++ b/.editorconfig
@@ -13,3 +13,7 @@ indent_size = 8
 [*.md]
 indent_style = space
 indent_size = 2
+
+[*.yml]
+indent_style = space
+indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+# EditorConfig is awesome: https://editorconfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+indent_style = tab
+indent_size = 8
+
+[*.md]
+indent_style = space
+indent_size = 2

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -50,7 +50,7 @@ jobs:
       # Run Linter against code base #
       ################################
       - name: Super-linter
-        uses: super-linter/super-linter@v7.4.0
+        uses: super-linter/super-linter@v8.0.0
         env:
           VALIDATE_ALL_CODEBASE: false
           DEFAULT_BRANCH: master

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -21,7 +21,7 @@ on:
   pull_request:
     branches: [master]
 
-#permissions: read-all
+permissions: read-all
 
 ###############
 # Set the Job #

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -21,7 +21,7 @@ on:
   pull_request:
     branches: [master]
 
-permissions: read-all
+#permissions: read-all
 
 ###############
 # Set the Job #
@@ -32,6 +32,12 @@ jobs:
     name: Lint Code Base
     # Set the agent to run on
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: read
+      # To report GitHub Actions status checks
+      statuses: write
 
     ##################
     # Load all steps #

--- a/bin/start_tmux
+++ b/bin/start_tmux
@@ -41,12 +41,13 @@ case `hostname` in
 	;;
 
 	hellonurse.* )
-		tmux new-session -s hellonurse -n logs -d "bc"
+		our_new_session hellonurse
 		sleep 1
-		tmux new-window -t hellonurse -d -n dnetc -c /home/chicks/Documents/dnetc -d "./dnetc"
-		tmux new-window -t hellonurse -d -n dnetc_meta -c /home/chicks/Documents/dnetc
-		#tmux new-window -t hellonurse -d -n logs -c /var/log -d "tail -f /var/log/messages"
-		tmux attach -t hellonurse
+		our_new_window hellonurse logs /var/logs
+		our_new_window hellonurse dnetc /home/chicks/Documents/dnetc
+		our_new_window hellonurse dnetc_meta /home/chicks/Documents/dnetc
+		our_attach hellonurse
+
 	;;
 
 	c64.* )

--- a/bin/start_tmux
+++ b/bin/start_tmux
@@ -25,7 +25,7 @@ function our_attach {
 	tmux attach -t "$SESSION_NAME"
 }
 
-case `hostname` in
+case $(hostname) in
 
 	freshfruit* )
 		our_new_session fruity

--- a/bin/start_tmux
+++ b/bin/start_tmux
@@ -27,7 +27,7 @@ function our_attach {
 
 case $(hostname) in
 
-	freshfruit* )
+	freshfruit*)
 		our_new_session fruity
 		our_new_window fruity www-chicks ~/Documents/git/www-chicks-net
 		our_new_window fruity www-fini ~/Documents/git/www-fini-net
@@ -38,9 +38,9 @@ case $(hostname) in
 		our_new_window fruity other ~/Documents/git/
 		our_attach fruity
 
-	;;
+		;;
 
-	hellonurse.* )
+	hellonurse.*)
 		our_new_session hellonurse
 		sleep 1
 		our_new_window hellonurse logs /var/logs
@@ -48,16 +48,16 @@ case $(hostname) in
 		our_new_window hellonurse dnetc_meta /home/chicks/Documents/dnetc
 		our_attach hellonurse
 
-	;;
+		;;
 
-	c64.* )
+	c64.*)
 		tmux new-session -s c64 -n bc -d "bc"
 		tmux new-window -t c64 -d -n dnetc_proxy #-c /home/chicks/Documents/git/fini-dnet-proxy
-		tmux new-window -t c64 -d -n dnetc #-c /home/chicks/Documents/dnetc
+		tmux new-window -t c64 -d -n dnetc       #-c /home/chicks/Documents/dnetc
 		tmux attach -t c64
-	;;
+		;;
 
-	efba* )
+	efba*)
 		our_new_session podman
 		our_new_window podman foo /etc
 		our_new_window podman bar /chicksbin
@@ -65,9 +65,9 @@ case $(hostname) in
 		our_new_window podman profit /proc
 		our_attach podman
 
-	;;
+		;;
 
-	* )
+	*)
 		echo generating default tmux session...
 		our_new_session defacto
 		our_new_window defacto foo
@@ -76,6 +76,6 @@ case $(hostname) in
 		our_new_window defacto profit
 		our_attach defacto
 
-	;;
+		;;
 
 esac

--- a/bin/start_tmux
+++ b/bin/start_tmux
@@ -2,7 +2,7 @@
 
 function our_new_session {
 	SESSION_NAME="${1:-default}"
-	echo "generating tmux session '$SESSION_NAME' on host '`hostname`'"
+	echo "generating tmux session '$SESSION_NAME' on host '$(hostname)'"
 	tmux new-session -s "$SESSION_NAME" -n bc -d
 	# thanks to https://stackoverflow.com/a/64037405/2002471
 	tmux send-keys -t "$SESSION_NAME" "bc" Enter


### PR DESCRIPTION
## Context:

It was failing with `Failed to call GitHub Status API` during super-linter runs.  This GHA has been higher maintenance than I hoped when I started with it over 4 years ago!  (See #2)

## Done:

- 🧹 [gha] update super-linter to 8.0.0
- try testing a shell script and fail a few times 🥉 
- update permissions to follow the current docs (give status write permission)
- add an `/.editorconfig` for the first time and then tweak it with various hidden options
- learn about some new tools 😁 


(Automated in `justfile`.)
