### PR TITLE
⏲ [git] git add is now verbose yet it remains silent when not actually adding anything

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -9,6 +9,7 @@
 
 [alias]
 	ack = ! git ls-files $GIT_PREFIX | ack -x
+	add = add --verbose
 	co = checkout
 	pushup = ! git push -u origin HEAD
 	ci = commit


### PR DESCRIPTION
## Done:

- ⏲ [git] git add is now verbose yet it remains silent when not actually adding anything


(Automated in `justfile`.)
